### PR TITLE
allow using a wrapped net.TCPConn in NewConn

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -46,3 +46,18 @@ func TestConn(t *testing.T) {
 		return tc, p.Conn, func() { tc.Close(); p.Conn.Close() }, nil
 	})
 }
+
+func TestWrappedConn(t *testing.T) {
+	type wrappedConn struct{ *net.TCPConn }
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.DialTCP("tcp", nil, ln.Addr().(*net.TCPAddr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = tcp.NewConn(&wrappedConn{conn}); err != nil {
+		t.Fatalf("couldn't initialize from a wrapped conn: %v", err)
+	}
+}

--- a/rawconn.go
+++ b/rawconn.go
@@ -97,9 +97,14 @@ func (c *Conn) available() int {
 
 // NewConn returns a new end point.
 func NewConn(c net.Conn) (*Conn, error) {
+	type tcpConn interface {
+		SyscallConn() (syscall.RawConn, error)
+		SetLinger(int) error
+	}
+	var _ tcpConn = &net.TCPConn{}
 	cc := &Conn{Conn: c}
 	switch c := c.(type) {
-	case *net.TCPConn:
+	case tcpConn:
 		var err error
 		cc.c, err = c.SyscallConn()
 		if err != nil {


### PR DESCRIPTION
Currently, the connection passed to `NewConn` has to be a `*net.TCPConn`, even though the function allows for a `net.Conn` to be passed. This is because `NewConn` performs a type assertion:
https://github.com/mikioh/tcp/blob/803a9b46060c1d8b9ee03ff0386b87c179f50227/rawconn.go#L99-L112

It would be nice if it was possible to pass a wrapped `*net.TCPConn` to `NewConn`. This should be a problem, as the only function actually needed is `SyscallConn()`. By doing an interface assertion using an interface only fulfilled by a `net.TCPConn`, we can even make sure that we don't accidentally use this package with a connection that's not a TCP connection.